### PR TITLE
fixed question formatting on mobile

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -9,16 +9,26 @@ html {
   background-color: #06070B;
 }
 
-.container {
-  width: 60%;
-  border: white 0px solid;
-  padding: 10px;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%,-50%);
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
+@media only screen and (min-width: 601px) { 
+  .container {
+    padding: 10px;
+    width: 60%;
+    border: white 0px solid;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%,-50%);
+    -webkit-transform: translate(-50%,-50%);
+    -ms-transform: translate(-50%,-50%);
+  }
+}
+
+@media only screen and (max-width: 600px) { 
+  .container {
+    width: auto;
+    margin: auto;
+    width: 80%;
+  }
 }
 
 .parent-container{


### PR DESCRIPTION
#3 
Currently on mobile the formatting of the questions puts many of them off screen, this is a quick fix to remove this problem.

I've basically just moved all the styling for desktop into one media query and added another for mobile.

## before:
### desktop
![Screenshot_20220502_093213](https://user-images.githubusercontent.com/52494104/166206782-cfa21684-1cdc-4416-b8a8-1190f195b975.png)
### mobile
![Screenshot_20220502_093242](https://user-images.githubusercontent.com/52494104/166206815-792ad05a-a159-4d55-81df-b07b8ee8da4b.png)

## after
### desktop
![Screenshot_20220502_092739](https://user-images.githubusercontent.com/52494104/166206893-28519935-d968-46d3-ad86-19634c8d1950.png)
### mobile
![Screenshot_20220502_093508](https://user-images.githubusercontent.com/52494104/166207047-11b03d22-5f1b-4024-9617-4e6ae457b976.png)


